### PR TITLE
allow option for using the slow tokenizer

### DIFF
--- a/lmms_eval/models/llava_hf.py
+++ b/lmms_eval/models/llava_hf.py
@@ -52,6 +52,7 @@ class LlavaHf(lmms):
         device_map: str = "",
         chat_template: Optional[str] = None,
         use_cache: bool = True,
+        fast_tokenizer: bool = True,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -77,7 +78,7 @@ class LlavaHf(lmms):
             self._model = LlavaForConditionalGeneration.from_pretrained(pretrained, revision=revision, torch_dtype=dtype, device_map=self.device_map, trust_remote_code=trust_remote_code, attn_implementation=attn_implementation)
 
         self.pretrained = pretrained
-        self._image_processor = AutoProcessor.from_pretrained(pretrained, revision=revision, trust_remote_code=trust_remote_code)
+        self._image_processor = AutoProcessor.from_pretrained(pretrained, revision=revision, trust_remote_code=trust_remote_code, use_fast=fast_tokenizer)
         # Pad from left for batched generation: https://huggingface.co/docs/transformers/v4.39.3/en/model_doc/llava#usage-tips
         self._image_processor.tokenizer.padding_side = "left"
         self._tokenizer = self._image_processor.tokenizer

--- a/run_scripts/template.sh
+++ b/run_scripts/template.sh
@@ -11,7 +11,7 @@ else
 fi
 
 if [[ $model_name == *"llava_hf"* ]]; then
-    model_args+=",device_map=auto,dtype=bfloat16"
+    model_args+=",device_map=auto,dtype=bfloat16,fast_tokenizer=False"
 fi
 
 echo $logger_name


### PR DESCRIPTION
- Allow for specifying a slow tokenizer for llava_hf models. 
- Default will remain the same (use fast tokenizer). 
- Edit the llava run script template to add `fast_tokenizer=False` to the pretrained args