### PR TITLE
Add validation split for docqa_ja

### DIFF
--- a/lmms_eval/tasks/docqa_ja/docqa_ja_val.yaml
+++ b/lmms_eval/tasks/docqa_ja/docqa_ja_val.yaml
@@ -21,4 +21,3 @@ metric_list:
   #   aggregation: mean
   #   higher_is_better: true
   #   query: true
-  

--- a/lmms_eval/tasks/docqa_ja/docqa_ja_val.yaml
+++ b/lmms_eval/tasks/docqa_ja/docqa_ja_val.yaml
@@ -21,3 +21,4 @@ metric_list:
   #   aggregation: mean
   #   higher_is_better: true
   #   query: true
+  

--- a/lmms_eval/tasks/docqa_ja/docqa_ja_val.yaml
+++ b/lmms_eval/tasks/docqa_ja/docqa_ja_val.yaml
@@ -1,0 +1,23 @@
+dataset_path: EtashGuha/JapaneseDocQA
+task: "docqa_ja_val"
+output_type: generate_until
+test_split: val
+doc_to_visual: !function utils.docvqa_doc_to_visual
+doc_to_text: !function utils.docvqa_doc_to_text
+doc_to_target: "original_answer"
+generation_kwargs:
+  max_new_tokens: 32
+  temperature: 0
+  do_sample: False
+model_specific_prompt_kwargs:
+  default:
+    pre_prompt: "\n1 つの単語またはフレーズを使用して質問に答えます。"
+    post_prompt: "日本語での回答:"
+metric_list:
+  - metric: anls
+    aggregation: mean
+    higher_is_better: true
+  # - metric: sambajudge
+  #   aggregation: mean
+  #   higher_is_better: true
+  #   query: true


### PR DESCRIPTION
Make a new task, `docqa_ja_val`, that iterates over the validation split of Etash's JaDocQA dataset on Huggingface: https://huggingface.co/datasets/EtashGuha/JapaneseDocQA
