### PR TITLE
Update method of specifying fast tokenizer

### DIFF
--- a/lmms_eval/models/llava_hf.py
+++ b/lmms_eval/models/llava_hf.py
@@ -52,7 +52,7 @@ class LlavaHf(lmms):
         device_map: str = "",
         chat_template: Optional[str] = None,
         use_cache: bool = True,
-        fast_tokenizer: bool = True,
+        fast_tokenizer: Optional[bool] = None,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -78,7 +78,15 @@ class LlavaHf(lmms):
             self._model = LlavaForConditionalGeneration.from_pretrained(pretrained, revision=revision, torch_dtype=dtype, device_map=self.device_map, trust_remote_code=trust_remote_code, attn_implementation=attn_implementation)
 
         self.pretrained = pretrained
-        self._image_processor = AutoProcessor.from_pretrained(pretrained, revision=revision, trust_remote_code=trust_remote_code, use_fast=fast_tokenizer)
+        processor_kwargs = {
+            'revision': revision,
+            'trust_remote_code': trust_remote_code
+        }
+        if fast_tokenizer is not None:
+            processor_kwargs['use_fast'] = fast_tokenizer
+        # strange bug where even if you supply `use_fast=True`, the default value, to AutoProcessor,
+        # the tokenizer will sometimes have the incorrect vocab size
+        self._image_processor = AutoProcessor.from_pretrained(pretrained, **processor_kwargs)
         # Pad from left for batched generation: https://huggingface.co/docs/transformers/v4.39.3/en/model_doc/llava#usage-tips
         self._image_processor.tokenizer.padding_side = "left"
         self._tokenizer = self._image_processor.tokenizer


### PR DESCRIPTION
Currently, the tokenizer for Llava is pulled from the image_processor object. For some reason, when specifying whether to use a fast tokenizer or not, adding this kwarg may result in an incorrect vocab size in some cases (still not root-caused).

Test-case: model merge of the following two models results in a broken tokenizer at evaluation time
- https://huggingface.co/elyza/ELYZA-japanese-Llama-2-7b-fast-instruct
- https://huggingface.co/llava-hf/llava-1.5-7b-hf

Fix: do not add in the `use_fast` kwarg for processor instantiation if it is not specified in the command line.
