### PR TITLE
Update max token length of docqaja

### DIFF
--- a/lmms_eval/tasks/docqa_ja/docqa_ja.yaml
+++ b/lmms_eval/tasks/docqa_ja/docqa_ja.yaml
@@ -6,7 +6,7 @@ doc_to_visual: !function utils.docvqa_doc_to_visual
 doc_to_text: !function utils.docvqa_doc_to_text
 doc_to_target: "original_answer"
 generation_kwargs:
-  max_new_tokens: 32
+  max_new_tokens: 256
   temperature: 0
   do_sample: False
 model_specific_prompt_kwargs:

--- a/lmms_eval/tasks/docqa_ja/docqa_ja_onlytext.yaml
+++ b/lmms_eval/tasks/docqa_ja/docqa_ja_onlytext.yaml
@@ -6,7 +6,7 @@ doc_to_visual: !function utils.docvqa_doc_to_visual
 doc_to_text: !function utils.docvqa_doc_to_textonly
 doc_to_target: "original_answer"
 generation_kwargs:
-  max_new_tokens: 32
+  max_new_tokens: 256
   temperature: 0
   do_sample: False
 model_specific_prompt_kwargs:

--- a/lmms_eval/tasks/docqa_ja/docqa_ja_val.yaml
+++ b/lmms_eval/tasks/docqa_ja/docqa_ja_val.yaml
@@ -6,7 +6,7 @@ doc_to_visual: !function utils.docvqa_doc_to_visual
 doc_to_text: !function utils.docvqa_doc_to_text
 doc_to_target: "original_answer"
 generation_kwargs:
-  max_new_tokens: 32
+  max_new_tokens: 256
   temperature: 0
   do_sample: False
 model_specific_prompt_kwargs:


### PR DESCRIPTION
Reviewing stats of https://huggingface.co/datasets/EtashGuha/JapaneseDocQA

```
>>> test_lens = [len(tokenizer.encode(x['original_answer'])) for x in ds['test']]
>>> val_lens = [len(tokenizer.encode(x['original_answer'])) for x in ds['val']]
>>> np.max(test_lens)
255
>>> np.max(val_lens)
236
>>> np.mean(test_lens)
33.40179573512907
>>> np.mean(val_lens)
32.62980209545984
```
Qualitatively, many model generations get cut off after only 32 tokens. This doesn't seem to impact ANLS much, but may impact GPT-4-Judge scores.
