### PR TITLE
Handle content filter from Azure

### DIFF
--- a/lmms_eval/api/metrics.py
+++ b/lmms_eval/api/metrics.py
@@ -222,7 +222,7 @@ def anls(
 def gpt4judge(references, predictions, query):  # This is a passthrough function
     """https://github.com/QwenLM/Qwen-VL/blob/master/eval_mm/infographicsvqa_eval.py"""
     values = []
-    from openai import AzureOpenAI
+    from openai import AzureOpenAI, BadRequestError
 
     NUM_SECONDS_TO_SLEEP = 30
     responses = []
@@ -264,7 +264,10 @@ def gpt4judge(references, predictions, query):  # This is a passthrough function
                 if attempt <= 3:
                     time.sleep(NUM_SECONDS_TO_SLEEP)
                 else:  # If this was the last attempt, log and return empty string
-                    eval_logger.error(f"All 5 attempts failed. Last error message: {str(e)}.\nResponse: {response.json()}")
+                    if isinstance(e, BadRequestError) and e.code == 'content_filter':
+                        eval_logger.error(f'Ran into a content filter error.\n***Original question***:\n{query}\n***Original ground truth answer***:\n{gt_answer}\n***Original model response***:\n{det_answer}')
+                        raise e
+                    eval_logger.error(f"All 5 attempts failed. Last error message: {str(e)}.\nResponse: {str(error_msg)}")
                     response = ""
 
         score = int(extract_number_from_brackets(response))

--- a/lmms_eval/api/metrics.py
+++ b/lmms_eval/api/metrics.py
@@ -260,7 +260,7 @@ def gpt4judge(references, predictions, query):  # This is a passthrough function
                 except:
                     error_msg = ""
 
-                eval_logger.info(f"Attempt {attempt + 1} failed with error: {str(e)}.\nReponse: {error_msg}")
+                eval_logger.info(f"Attempt {attempt + 1} failed with error: {str(e)}.\nError message: {error_msg}")
                 if attempt <= 3:
                     time.sleep(NUM_SECONDS_TO_SLEEP)
                 else:  # If this was the last attempt, log and return empty string

--- a/miscs/offline_gpt4_eval.py
+++ b/miscs/offline_gpt4_eval.py
@@ -30,6 +30,7 @@ if __name__ == '__main__':
 
     gpt4_judge_logs = []
     correct = []
+    skipped = []
 
     logs = result_json['logs']
     for log in tqdm(logs, dynamic_ncols=True, desc=f'Judging answers', total=len(logs)):
@@ -50,6 +51,7 @@ if __name__ == '__main__':
             if e.code == 'content_filter':
                 doc_id = log["doc_id"]
                 print(f'Ran into a content filter error at document ID {doc_id}, skipping!\n***question {doc_id}***:\n{query}\n***ground truth answer {doc_id}***:\n{gt_answer}\n***model response {doc_id}***:\n{det_answer}')
+                skipped.append(doc_id)
                 continue
                 
         correct_or_not = gpt4_judge_response_dict['gpt4judge']
@@ -70,6 +72,8 @@ if __name__ == '__main__':
         'gpt4judge': total_correct,
         'gpt4judge_stderr': mean_stderr(correct),
         'logs': gpt4_judge_logs,
+        'content_filtered': len(skipped),
+        'content_filtered_ids': skipped,
     }
     with open(gpt4_results_path, 'w') as f:
         json.dump(gpt4judge_json, f)
@@ -77,3 +81,5 @@ if __name__ == '__main__':
     print(f'Original results path = {str(result_json_path.absolute())}')
     print(f'gpt4judge: {total_correct}')
     print(f'gpt4judge_stderr: {mean_stderr(correct)}')
+    print(f'Number of content filtered documents: {len(skipped)}')
+    print(f'Content filtered documents: {skipped}')

--- a/miscs/offline_gpt4_eval.py
+++ b/miscs/offline_gpt4_eval.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
         except openai.BadRequestError as e:
             if e.code == 'content_filter':
                 doc_id = log["doc_id"]
-                print(f'Ran into a content filter error at document ID {doc_id}, skipping!\n***question {doc_id}***:\n{query}\n***ground truth answer {doc_id}***:\n{gt_answer}\n***model response {doc_id}***:\n{det_answer}')
+                print(f'Ran into a content filter error at document ID {doc_id}, skipping!\n***question {doc_id}***:\n{question_text}\n***ground truth answers {doc_id}***:\n{reference_answers}\n***model response {doc_id}***:\n{predictions}')
                 skipped.append(doc_id)
                 continue
                 

--- a/miscs/offline_gpt4_eval.py
+++ b/miscs/offline_gpt4_eval.py
@@ -82,4 +82,4 @@ if __name__ == '__main__':
     print(f'gpt4judge: {total_correct}')
     print(f'gpt4judge_stderr: {mean_stderr(correct)}')
     print(f'Number of content filtered documents: {len(skipped)}')
-    print(f'Content filtered documents: {skipped}')
+    print(f'Content filtered document IDs: {skipped}')


### PR DESCRIPTION
Some documents unintentionally activate OpenAI's content filter. Catch and log those in an informative way for gpt4judge as a metric, and skip them for offline evlauations.
