### PR TITLE
Initial commit to add binary and non-binary splits to jdocvqa

### DIFF
--- a/lmms_eval/api/metrics.py
+++ b/lmms_eval/api/metrics.py
@@ -57,9 +57,33 @@ def f1_score(items):
     golds = unzipped_list[0]
     preds = unzipped_list[1]
     fscore = sklearn.metrics.f1_score(golds, preds)
-
     return np.max(fscore)
 
+@register_aggregation("binary_mean_f1")
+def binary_mean_f1_score(items):
+    preds, golds = zip(*items)
+    preds = np.array(preds)
+    golds = np.array(golds)
+    f11 = sklearn.metrics.f1_score(y_true=golds == 0, y_pred=preds == 0)
+    f12 = sklearn.metrics.f1_score(y_true=golds == 1, y_pred=preds == 1)
+    avg_f1 = np.mean([f11, f12])
+    return avg_f1
+
+@register_aggregation("binary_f1_0")
+def binary_f1_0_score(items):
+    preds, golds = zip(*items)
+    preds = np.array(preds)
+    golds = np.array(golds)
+    f11 = sklearn.metrics.f1_score(y_true=golds == 0, y_pred=preds == 0)
+    return f11
+
+@register_aggregation("binary_f1_1")
+def binary_f1_1_score(items):
+    preds, golds = zip(*items)
+    preds = np.array(preds)
+    golds = np.array(golds)
+    f12 = sklearn.metrics.f1_score(y_true=golds == 1, y_pred=preds == 1)
+    return f12
 
 @register_aggregation("matthews_corrcoef")
 def matthews_corrcoef(items):
@@ -421,6 +445,33 @@ def mcc_fn(items):  # This is a passthrough function
     aggregation="f1",
 )
 def f1_fn(items):  # This is a passthrough function
+    return items
+
+@register_metric(
+    metric="binary_mean_f1",
+    higher_is_better=True,
+    output_type="multiple_choice",
+    aggregation="binary_mean_f1",
+)
+def mean_f1_fn(items):  # This is a passthrough function
+    return items
+
+@register_metric(
+    metric="f1_0",
+    higher_is_better=True,
+    output_type="multiple_choice",
+    aggregation="binary_f1_0",
+)
+def f1_0_fn(items):  # This is a passthrough function
+    return items
+
+@register_metric(
+    metric="f1_1",
+    higher_is_better=True,
+    output_type="multiple_choice",
+    aggregation="binary_f1_1",
+)
+def f1_1_fn(items):  # This is a passthrough function
     return items
 
 

--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -1159,13 +1159,13 @@ class ConfigurableTask(Task):
         use_metric = list(self._metric_fn_list.keys())
         if self.OUTPUT_TYPE == "loglikelihood":
             results = results[0]
-            ll, is_greedy = results
+            ll, is_greedy, _ = results
             return {
                 **({"perplexity": ll} if "perplexity" in use_metric else {}),
                 **({"acc": int(is_greedy)} if "acc" in use_metric else {}),
             }
         elif self.OUTPUT_TYPE == "multiple_choice":
-            lls, is_greedy = zip(*results)
+            lls, is_greedy, _ = zip(*results)
 
             # retrieve choices in List[str] form, to compute choice lengths, etc.
             choices = self.doc_to_choice(doc)

--- a/lmms_eval/api/task.py
+++ b/lmms_eval/api/task.py
@@ -1217,6 +1217,9 @@ class ConfigurableTask(Task):
             result_dict = {
                 **({"acc": acc} if "acc" in use_metric else {}),
                 **({"f1": (gold, pred)} if "f1" in use_metric else {}),
+                **({"binary_mean_f1": (gold, pred)} if "binary_mean_f1" in use_metric else {}),
+                **({"f1_0": (gold, pred)} if "f1_0" in use_metric else {}),
+                **({"f1_1": (gold, pred)} if "f1_1" in use_metric else {}),
                 **({"mcc": (gold, pred)} if "mcc" in use_metric else {}),
                 **({"acc_norm": acc_norm} if "acc_norm" in use_metric else {}),
                 **({"exact_match": exact_match} if "exact_match" in use_metric else {}),

--- a/lmms_eval/models/internvl2.py
+++ b/lmms_eval/models/internvl2.py
@@ -620,9 +620,9 @@ class InternVL2(lmms):
             loss = outputs["loss"]
             logits = outputs["logits"]
             greedy_tokens = logits.argmax(dim=-1)
-            cont_toks = model_inputs["input_ids"][:, contxt_id.shape[1] + role_length:]
-            # account for off by 1
-            greedy_toks = greedy_tokens[:, contxt_id.shape[1] + role_length - 1:-1]
+            cont_toks = model_inputs["input_ids"][:, contxt_id.shape[1] + role_length:-1]
+            # account for off by 1 and im_end
+            greedy_toks = greedy_tokens[:, contxt_id.shape[1] + role_length - 1:-2]
             max_equal = (greedy_toks == cont_toks).all()
             res.append((float(loss.item()), bool(max_equal), self.tokenizer.decode(greedy_toks[0])))
             pbar.update(1)

--- a/lmms_eval/tasks/docvqa_ja/docvqa_ja_binary.yaml
+++ b/lmms_eval/tasks/docvqa_ja/docvqa_ja_binary.yaml
@@ -1,0 +1,15 @@
+dataset_path: jlli/JDocQA-binary
+task: "docvqa_ja_binary"
+output_type: loglikelihood
+test_split: test
+doc_to_visual: !function utils.docvqa_doc_to_visual
+doc_to_text: !function utils.docvqa_doc_to_text
+doc_to_target: "original_answer"
+model_specific_prompt_kwargs:
+  default:
+    pre_prompt: "\n1 つの単語またはフレーズを使用して質問に答えます。"
+    post_prompt: "日本語での回答:"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true

--- a/lmms_eval/tasks/docvqa_ja/docvqa_ja_binary_mc.yaml
+++ b/lmms_eval/tasks/docvqa_ja/docvqa_ja_binary_mc.yaml
@@ -1,0 +1,16 @@
+dataset_path: jlli/JDocQA-binary
+task: "docvqa_ja_binary_mc"
+output_type: multiple_choice
+test_split: test
+doc_to_visual: !function utils.docvqa_doc_to_visual
+doc_to_text: !function utils.docvqa_doc_to_text
+doc_to_choice: !function utils.docvqa_doc_to_choice
+doc_to_target: "original_answer"
+model_specific_prompt_kwargs:
+  default:
+    pre_prompt: "\n1 つの単語またはフレーズを使用して質問に答えます。"
+    post_prompt: "日本語での回答:"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true

--- a/lmms_eval/tasks/docvqa_ja/docvqa_ja_binary_mc.yaml
+++ b/lmms_eval/tasks/docvqa_ja/docvqa_ja_binary_mc.yaml
@@ -14,3 +14,12 @@ metric_list:
   - metric: acc
     aggregation: mean
     higher_is_better: true
+  - metric: binary_mean_f1
+    aggregation: binary_mean_f1
+    higher_is_better: true
+  - metric: f1_0
+    aggregation: binary_f1_0
+    higher_is_better: true
+  - metric: f1_1
+    aggregation: binary_f1_1
+    higher_is_better: true

--- a/lmms_eval/tasks/docvqa_ja/docvqa_ja_nonbinary.yaml
+++ b/lmms_eval/tasks/docvqa_ja/docvqa_ja_nonbinary.yaml
@@ -1,0 +1,27 @@
+dataset_path: jlli/JDocQA-nonbinary
+task: "docvqa_ja_nonbinary"
+output_type: generate_until
+test_split: test
+doc_to_visual: !function utils.docvqa_doc_to_visual
+doc_to_text: !function utils.docvqa_doc_to_text
+doc_to_target: "original_answer"
+generation_kwargs:
+  max_new_tokens: 256
+  temperature: 0
+  do_sample: False
+model_specific_prompt_kwargs:
+  default:
+    pre_prompt: "\n1 つの単語またはフレーズを使用して質問に答えます。"
+    post_prompt: "日本語での回答:"
+metric_list:
+  - metric: anls
+    aggregation: mean
+    higher_is_better: true
+  - metric: sambajudge
+    aggregation: mean
+    higher_is_better: true
+    query: true
+  - metric: gpt4judge
+    aggregation: mean
+    higher_is_better: true
+    query: true

--- a/lmms_eval/tasks/docvqa_ja/utils.py
+++ b/lmms_eval/tasks/docvqa_ja/utils.py
@@ -17,6 +17,8 @@ def docvqa_doc_to_text(doc, model_specific_prompt_kwargs):
     post_prompt = model_specific_prompt_kwargs["post_prompt"]
     return f"{pre_prompt}{question}{post_prompt}"
 
+def docvqa_doc_to_choice(doc):
+    return ['はい', 'いいえ']
 
 def docvqa_doc_to_textonly(doc, model_specific_prompt_kwargs):
     all_text = doc["text"]


### PR DESCRIPTION
~10% of the JDocVQA questions are simple yes or no answers, which can be considered "easy". While they might obfuscate the signal and difficulty of the task, they are much simpler to evaluate. Add binary and nonbinary splits to these tasks, as well as add an additional output to llava_hf's loglikelihood