### PR TITLE
Add Sambastudio LLaVA connector

### DIFF
--- a/lmms_eval/models/__init__.py
+++ b/lmms_eval/models/__init__.py
@@ -30,6 +30,7 @@ AVAILABLE_MODELS = {
     "videoChatGPT": "VideoChatGPT",
     "llama_vid": "LLaMAVid",
     "video_llava": "VideoLLaVA",
+    "ss_llava": "SambaStudioLLaVA",
     "xcomposer2_4KHD": "XComposer2_4KHD",
     "claude": "Claude",
     "qwen_vl_api": "Qwen_VL_API",

--- a/lmms_eval/models/ss_llava.py
+++ b/lmms_eval/models/ss_llava.py
@@ -1,0 +1,168 @@
+from io import BytesIO
+import os
+import base64
+from typing import List, Tuple
+from tqdm import tqdm
+import requests as url_requests
+import time
+import json
+
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.model import lmms
+from lmms_eval.api.registry import register_model
+
+from accelerate import Accelerator, DistributedType
+
+from PIL import Image
+
+NUM_SECONDS_TO_SLEEP = 30
+from loguru import logger as eval_logger
+
+@register_model("ss_llava")
+class SambaStudioLLaVA(lmms):
+    def __init__(
+        self,
+        endpoint_url: str = "",
+        endpoint_key: str = "",
+        timeout: int = 120,
+        continual_mode: bool = False,
+        response_persistent_folder: str = None,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+
+        self.endpoint_url = endpoint_url
+        self.endpoint_key = endpoint_key
+
+        self.headers = {
+            "key": endpoint_key,
+            "Content-Type": "application/json",
+        }
+        self.image_token = "<image>"
+        self.timeout = timeout
+        self.continual_mode = continual_mode
+        if self.continual_mode:
+            if response_persistent_folder is None:
+                raise ValueError("Continual mode requires a persistent path for the response. Please provide a valid path.")
+
+            os.makedirs(response_persistent_folder, exist_ok=True)
+            self.response_persistent_folder = response_persistent_folder
+            self.response_persistent_file = os.path.join(self.response_persistent_folder, f"{self.model_version}_response.json")
+
+            if os.path.exists(self.response_persistent_file):
+                with open(self.response_persistent_file, "r") as f:
+                    self.response_cache = json.load(f)
+                self.cache_mode = "resume"
+            else:
+                self.response_cache = {}
+                self.cache_mode = "start"
+
+        accelerator = Accelerator()
+        if accelerator.num_processes > 1:
+            assert accelerator.distributed_type in [DistributedType.FSDP, DistributedType.MULTI_GPU, DistributedType.DEEPSPEED], "Unsupported distributed type provided. Only DDP and FSDP are supported."
+            self.accelerator = accelerator
+            if self.accelerator.is_local_main_process:
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
+            self._rank = self.accelerator.local_process_index
+            self._world_size = self.accelerator.num_processes
+        else:
+            self.accelerator = accelerator
+            self._rank = self.accelerator.local_process_index
+            self._world_size = self.accelerator.num_processes
+
+        self.device = self.accelerator.device
+
+    # Function to encode the image
+    def encode_image(self, image: Image):
+        output_buffer = BytesIO()
+        image.save(output_buffer, format="PNG")
+        byte_data = output_buffer.getvalue()
+        base64_str = base64.b64encode(byte_data).decode("utf-8")
+        return base64_str
+
+    def flatten(self, input):
+        new_list = []
+        for i in input:
+            for j in i:
+                new_list.append(j)
+        return new_list
+
+    def generate_until(self, requests) -> List[str]:
+        res = []
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="Model Responding")
+
+        for contexts, gen_kwargs, doc_to_visual, doc_id, task, split in [reg.args for reg in requests]:
+            if self.continual_mode is True and self.cache_mode == "resume":
+                doc_uuid = f"{task}___{split}___{doc_id}"
+                if doc_uuid in self.response_cache:
+                    response_text = self.response_cache[doc_uuid]
+                    if response_text:
+                        res.append(response_text)
+                        pbar.update(1)
+                        continue
+
+            visuals = [doc_to_visual(self.task_dict[task][split][doc_id])]
+            visuals = self.flatten(visuals)
+            
+            img = self.encode_image(visuals[0])
+
+            payload = {
+                "instances": [{
+                    "prompt": f"A chat between a curious human and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the human''s questions. USER: {self.image_token}\\n{contexts} ASSISTANT:",
+                    "image_content": img
+                }]
+            }
+                    
+            if "do_sample" not in gen_kwargs:
+                gen_kwargs["do_sample"] = False
+            if "max_new_tokens" not in gen_kwargs:
+                gen_kwargs["max_new_tokens"] = 1024
+            if gen_kwargs["max_new_tokens"] > 4096:
+                gen_kwargs["max_new_tokens"] = 4096
+            if "temperature" not in gen_kwargs:
+                gen_kwargs["temperature"] = 1
+            if "top_p" not in gen_kwargs:
+                gen_kwargs["top_p"] = 1
+            if "top_k" not in gen_kwargs:
+                gen_kwargs["top_k"] = 50
+            if "top_logprobs" not in gen_kwargs:
+                gen_kwargs["top_logprobs"] = 0
+
+            payload["params"] = gen_kwargs
+
+            for attempt in range(5):
+                try:
+                    response = url_requests.post(self.endpoint_url, headers=self.headers, json=payload, timeout=self.timeout)
+                    response_data = response.json()
+                    response_text = response_data["predictions"][0]["completion"].strip()
+                    break  # If successful, break out of the loop
+
+                except Exception as e:
+                    try:
+                        error_msg = response.json()
+                    except:
+                        error_msg = ""
+
+                    eval_logger.info(f"Attempt {attempt + 1} failed with error: {str(e)}.\nReponse: {error_msg}")
+                    if attempt <= 3:
+                        time.sleep(NUM_SECONDS_TO_SLEEP)
+                    else:  # If this was the last attempt, log and return empty string
+                        eval_logger.error(f"All 5 attempts failed. Last error message: {str(e)}.\nResponse: {response.json()}")
+                        response_text = ""
+
+            res.append(response_text)
+        
+            pbar.update(1)
+
+            if self.continual_mode is True:  # Cache the response
+                doc_uuid = f"{task}___{split}___{doc_id}"
+                self.response_cache[doc_uuid] = response_text
+                with open(self.response_persistent_file, "w") as f:
+                    json.dump(self.response_cache, f)
+
+        pbar.close()
+        return res
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        # TODO
+        assert False, "GPT4V not support"

--- a/lmms_eval/models/ss_llava.py
+++ b/lmms_eval/models/ss_llava.py
@@ -128,7 +128,14 @@ class SambaStudioLLaVA(lmms):
             if "top_logprobs" not in gen_kwargs:
                 gen_kwargs["top_logprobs"] = 0
 
-            payload["params"] = gen_kwargs
+            payload["params"] = {
+                'max_tokens_to_generate': {"type":"int","value":str(gen_kwargs["max_new_tokens"])},
+                'temperature':{"type":"float","value":str(gen_kwargs["temperature"])},
+                'top_p':{"type":"float","value":str(gen_kwargs["top_p"])},
+                'do_sample':{"type":"bool","value":str(gen_kwargs["do_sample"])},
+                'top_k':{"type":"int","value":str(gen_kwargs["top_k"])},
+                'top_logprobs':{"type":"int","value":str(gen_kwargs["top_logprobs"])}
+            }
 
             for attempt in range(5):
                 try:

--- a/lmms_eval/models/ss_llava.py
+++ b/lmms_eval/models/ss_llava.py
@@ -108,7 +108,7 @@ class SambaStudioLLaVA(lmms):
 
             payload = {
                 "instances": [{
-                    "prompt": f"A chat between a curious human and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the human''s questions. USER: {self.image_token}\\n{contexts} ASSISTANT:",
+                    "prompt": contexts,
                     "image_content": img
                 }]
             }

--- a/lmms_eval/models/ss_llava.py
+++ b/lmms_eval/models/ss_llava.py
@@ -172,4 +172,4 @@ class SambaStudioLLaVA(lmms):
 
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         # TODO
-        assert False, "GPT4V not support"
+        assert False, "SS-LLaVA not supported"


### PR DESCRIPTION
Adds a connector to use the Sambastudio LLaVA modelbox. It can be used by setting up the endpoint on samba studio and then providing the api url and key to the model_args parameter.

I used the GPT4 connector as the base. It has a few features that I'm still testing if they transferred over properly