### PR TITLE
Add logic to skip some failures in eval

### DIFF
--- a/lmms_eval/models/mmllama_sambacloud.py
+++ b/lmms_eval/models/mmllama_sambacloud.py
@@ -118,8 +118,8 @@ class MMLlamaSambaCloud(lmms):
 
                     eval_logger.info(f"Attempt {attempt + 1} failed with error: {str(e)}.\nReponse: {error_msg}")
                     if response.status_code == 413:
-                        eval_logger.error(f"Request too big for API, skipping. Image size = {visuals[0].size}")
-                        response_text = ""
+                        eval_logger.error(f"Request too big for API, skipping. Image size = {visuals[0].size}, encoded_image_size = {len(img)}, text size = {len(contexts)}")
+                        response_text = "<skipped_prediction>"
                         break
                     if attempt <= 3:
                         time.sleep(NUM_SECONDS_TO_SLEEP)


### PR DESCRIPTION
The samba studio api has some failure cases that are expected and while they are being fixed we'd like still like to be able to do some evaluations. This adds logic to not include known failures in the metric calculations by returning `<skipped_prediction>` from the model. The evaluator will then not include these in the final metric calculations, but also will include a count of the number skipped as well as a warning that these metrics aren't calculated with all the data. 