### PR TITLE
gptjudge empty response handling

### DIFF
--- a/lmms_eval/api/metrics.py
+++ b/lmms_eval/api/metrics.py
@@ -423,7 +423,7 @@ def sambajudge(references, predictions, query):  # This is a passthrough functio
     import requests
     import json
 
-    NUM_SECONDS_TO_SLEEP = 45
+    NUM_SECONDS_TO_SLEEP = 30
     from openai import OpenAI
 
     key = os.getenv("SAMBAKEY", None)
@@ -500,7 +500,6 @@ def sambajudge(references, predictions, query):  # This is a passthrough functio
 
 
 def extract_number_from_brackets(string):
-    print(" --- number to be extracted from brackets ----- ", string)
     # Regular expression to find numbers inside double brackets
     match = re.search(r"\[\[(\d+)\]\]", string)
     if match:

--- a/lmms_eval/api/metrics.py
+++ b/lmms_eval/api/metrics.py
@@ -405,7 +405,7 @@ def gpt4judge(references, predictions, query):  # This is a passthrough function
                     eval_logger.error(f"All 5 attempts failed. Last error message: {str(e)}.\nResponse: {str(error_msg)}")
                     response = ""
 
-        if response is None: # Rare case of gpt returning empty response
+        if response is None:  # Rare case of gpt returning empty response
             score = 0
         else:
             score = int(extract_number_from_brackets(response))

--- a/lmms_eval/api/metrics.py
+++ b/lmms_eval/api/metrics.py
@@ -405,7 +405,10 @@ def gpt4judge(references, predictions, query):  # This is a passthrough function
                     eval_logger.error(f"All 5 attempts failed. Last error message: {str(e)}.\nResponse: {str(error_msg)}")
                     response = ""
 
-        score = int(extract_number_from_brackets(response))
+        if response is None: # Rare case of gpt returning empty response
+            score = 0
+        else:
+            score = int(extract_number_from_brackets(response))
         responses.append(response)
         values.append(score)
 
@@ -420,7 +423,7 @@ def sambajudge(references, predictions, query):  # This is a passthrough functio
     import requests
     import json
 
-    NUM_SECONDS_TO_SLEEP = 30
+    NUM_SECONDS_TO_SLEEP = 45
     from openai import OpenAI
 
     key = os.getenv("SAMBAKEY", None)
@@ -497,6 +500,7 @@ def sambajudge(references, predictions, query):  # This is a passthrough functio
 
 
 def extract_number_from_brackets(string):
+    print(" --- number to be extracted from brackets ----- ", string)
     # Regular expression to find numbers inside double brackets
     match = re.search(r"\[\[(\d+)\]\]", string)
     if match:

--- a/lmms_eval/api/metrics.py
+++ b/lmms_eval/api/metrics.py
@@ -1,16 +1,16 @@
 # the code is adapted from https://github.com/EleutherAI/lm-evaluation-harness
 import logging
 import math
+import os
 import random
 import re
 import string
+import time
 from collections.abc import Iterable
 from typing import List
 
 import numpy as np
 import sacrebleu
-import os
-import time
 from transformers import AutoTokenizer
 
 from lmms_eval.api.registry import register_aggregation, register_metric
@@ -420,8 +420,9 @@ def sambajudge(references, predictions, query):  # This is a passthrough functio
     """https://github.com/QwenLM/Qwen-VL/blob/master/eval_mm/infographicsvqa_eval.py"""
     values = []
     responses = []
-    import requests
     import json
+
+    import requests
 
     NUM_SECONDS_TO_SLEEP = 30
     from openai import OpenAI


### PR DESCRIPTION
Occasionally when using gpt as a judge, the response is empty. From our test set, this occurred only once and is considered incorrect by default. 

Test command:
`python3 -m accelerate.commands.launch \
    --num_processes=1 \
    -m lmms_eval \
    --model internvl2 \
    --model_args pretrained="/import/ml-sc-scratch3/nidhih/mm_hungarian/finetune_outputs/pretrain_hupdf2_synthdog_hu_all_unfrozen" \
    --tasks docvqa_hu_syn \
    --batch_size 1 \
    --log_samples \
    --log_samples_suffix intervl2_8b \
    --output_path /import/ml-sc-scratch3/nidhih/mm_hungarian/lmms_eval_op/internvl2_8b_docvqasyn_pt_test \
    --limit 200`
