### PR TITLE
DocVQA Fixes

### DIFF
--- a/lmms_eval/tasks/docvqa_hu/docvqa_hu.yaml
+++ b/lmms_eval/tasks/docvqa_hu/docvqa_hu.yaml
@@ -4,7 +4,7 @@ output_type: generate_until
 test_split: test
 doc_to_visual: !function utils.docvqa_doc_to_visual
 doc_to_text: !function utils.docvqa_doc_to_text
-doc_to_target: "Short Answer"
+doc_to_target: !function utils.docvqa_doc_to_target
 generation_kwargs:
   max_new_tokens: 256
   temperature: 0

--- a/lmms_eval/tasks/docvqa_hu/utils.py
+++ b/lmms_eval/tasks/docvqa_hu/utils.py
@@ -18,6 +18,13 @@ def docvqa_doc_to_text(doc, model_specific_prompt_kwargs):
     return f"{pre_prompt}{question}{post_prompt}"
 
 
+def docvqa_doc_to_target(doc):
+    answer = doc['Short Answer']
+    if answer is None:
+        answer = doc['Answer']
+    return answer
+
+
 def docvqa_doc_to_textonly(doc, model_specific_prompt_kwargs):
     all_text = doc["pdf_extract_texts"]
     question = doc["Question"]

--- a/lmms_eval/tasks/docvqa_ja/docvqa_ja_nonbinary.yaml
+++ b/lmms_eval/tasks/docvqa_ja/docvqa_ja_nonbinary.yaml
@@ -3,25 +3,13 @@ task: "docvqa_ja_nonbinary"
 output_type: generate_until
 test_split: test
 doc_to_visual: !function utils.docvqa_doc_to_visual
-doc_to_text: !function utils.docvqa_doc_to_text
+doc_to_text: "question"
 doc_to_target: "original_answer"
 generation_kwargs:
-  max_new_tokens: 256
+  max_new_tokens: 1024
   temperature: 0
   do_sample: False
-lmms_eval_specific_kwargs:
-  default:
-    pre_prompt: "\n1 つの単語またはフレーズを使用して質問に答えます。"
-    post_prompt: "日本語での回答:"
 metric_list:
   - metric: anls
     aggregation: mean
     higher_is_better: true
-  - metric: sambajudge
-    aggregation: mean
-    higher_is_better: true
-    query: true
-  - metric: gpt4judge
-    aggregation: mean
-    higher_is_better: true
-    query: true


### PR DESCRIPTION
- remove pre-prompt and post-prompt for Japanese non-binary DocVQA
- extend max generation length for Japanese non-binary DocVQA to 1024
- account for missing "Short Answer" keys in Hungarian DocVQA